### PR TITLE
Update DokanNet API to match DokanNet commit f9b6493

### DIFF
--- a/DokanSSHFS/SettingForm.cs
+++ b/DokanSSHFS/SettingForm.cs
@@ -85,7 +85,7 @@ namespace DokanSSHFS
 
             if (DokanSSHFS.DokanDebug)
                 opt |= DokanOptions.DebugMode;
-            opt |= DokanOptions.AltStream | DokanOptions.KeepAlive;
+            opt |= DokanOptions.AltStream; // DokanOptions.KeepAlive always enabled.
             mountPoint = "n:\\";
             threadCount = 0;
 
@@ -197,7 +197,7 @@ namespace DokanSSHFS
                 }
                 // This should be called from Dokan, but not called.
                 // Call here explicitly.
-                sshfs.Unmount(null);
+                sshfs.Unmounted(null);
             }
             unmount.Visible = false;
             mount.Visible = true;


### PR DESCRIPTION
Hey Dokan people,

I wanted to use DokanSSHFS with the recent Dokan library and .NET wrapper, but the current version fails (after fixing DiffiHellman and Org.Mentalis.Security dependencies by getting them with the Nuget Package Manager) by not finding 'dokan.dll'. I assumed this is because the Dokan library has since been updated? Anyway, DokanNet has definitely changed.

This pull request updates DokanSSHFS to compile against the most recent commit of DokanNet. Built well (Visual Studio 2015) and works on Windows 10.

One thing to go over are my implementations of FindFilesWithPattern which aren't the best. DokanNet doesn't expose DokanIsNameInExpression, so I couldn't use it. This can be part of another pull request.

Yuval
