### PR TITLE
Fix dependencies and update icon

### DIFF
--- a/DokanSSHFS/DokanSSHFS.csproj
+++ b/DokanSSHFS/DokanSSHFS.csproj
@@ -74,8 +74,16 @@
     <ErrorReport>prompt</ErrorReport>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="DiffieHellman, Version=0.0.0.0, Culture=neutral">
+      <HintPath>packages\DiffieHellman.1.0.0\lib\net40\DiffieHellman.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="DokanNet, Version=0.7.0.0, Culture=neutral, processorArchitecture=x86">
       <HintPath>packages\DokanNet.1.0.5.0\lib\net40\DokanNet.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Org.Mentalis.Security, Version=1.0.13.715, Culture=neutral">
+      <HintPath>packages\Org.Mentalis.Security.1.0.0\lib\net40\Org.Mentalis.Security.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/DokanSSHFS/DokanSSHFS.csproj
+++ b/DokanSSHFS/DokanSSHFS.csproj
@@ -13,7 +13,7 @@
     <AssemblyName>DokanSSHFS</AssemblyName>
     <StartupObject>
     </StartupObject>
-    <ApplicationIcon>Icon2.ico</ApplicationIcon>
+    <ApplicationIcon>notify3.ico</ApplicationIcon>
     <FileUpgradeFlags>
     </FileUpgradeFlags>
     <OldToolsVersion>3.5</OldToolsVersion>

--- a/DokanSSHFS/packages.config
+++ b/DokanSSHFS/packages.config
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DokanNet" version="1.0.5.0" targetFramework="net40" />
+  <package id="DiffieHellman" version="1.0.0" targetFramework="net4" />
+  <package id="DokanNet" version="1.0.5.0" targetFramework="net4" />
+  <package id="Org.Mentalis.Security" version="1.0.0" targetFramework="net4" />
   <package id="Tamir.SharpSSH" version="1.1.1.13" targetFramework="net35" />
 </packages>


### PR DESCRIPTION
This PR is a re-package of https://github.com/dokan-dev/dokan-sshfs/pull/4 which added missing dependencies (and the commit from that PR is used) as well as a change of the icon of the build application to a prettier one already in the project.

This closes #4 and #1 by resolving the differences against `master` as of 658fa6c20, /cc @ration
